### PR TITLE
Add @ember/test-helpers to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "webdriverio": "^9.20.0"
   },
   "peerDependencies": {
-    "vitest": "^4.0.8"
+    "vitest": "^4.0.8",
+    "@ember/test-helpers": ">=4.0.0"
   },
   "packageManager": "pnpm@10.17.0",
   "engines": {


### PR DESCRIPTION
This fixes error I was facing:

> ember-vitest is trying to import from @ember/test-helpers but that is not one of its explicit dependencies

`@ember/test-helpers` v4 is when addon was converted to Addon v2 format so I assume it's minimally supported