### PR TITLE
Accept ComponentLike in setupRenderingContext().render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ jobs:
       - uses: wyvox/action@v2
       - run: pnpm lint
 
+  typecheck:
+    name: "Typecheck"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: wyvox/action@v2
+      - run: pnpm types:check
+
   tests:
     name: "Tests"
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build": "rollup --config",
     "lint": "prettier . --check",
     "lint:fix": "prettier . --write",
+    "types:check": "ember-tsc --noEmit -p tsconfig.glint.json",
     "test": "vitest run --browser.headless",
     "test:dev": "vitest",
     "prepack": "rollup --config"
@@ -62,6 +63,8 @@
     "@embroider/macros": "^1.18.1",
     "@embroider/vite": "^1.2.0",
     "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "^1.5.0",
+    "@glint/template": "^1.7.7",
     "@rollup/plugin-babel": "^7.0.0",
     "@testing-library/dom": "^10.4.1",
     "@vitest/browser": "^4.0.13",
@@ -81,7 +84,13 @@
   },
   "peerDependencies": {
     "@ember/test-helpers": ">=4.0.0",
+    "@glint/template": "^1.0.0",
     "vitest": "^4.0.8"
+  },
+  "peerDependenciesMeta": {
+    "@glint/template": {
+      "optional": true
+    }
   },
   "packageManager": "pnpm@10.24.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,22 +30,28 @@ importers:
         version: 2.0.0
       '@ember/test-helpers':
         specifier: ^5.4.0
-        version: 5.4.0(@babel/core@7.28.4)
+        version: 5.4.0(8612da301a9a8aaf6d70030350e5df34)
       '@embroider/addon-dev':
         specifier: ^8.1.2
-        version: 8.1.2(rollup@4.53.3)
+        version: 8.1.2(@glint/template@1.7.7)(rollup@4.53.3)
       '@embroider/core':
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(@glint/template@1.7.7)
       '@embroider/macros':
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(@glint/template@1.7.7)
       '@embroider/vite':
         specifier: ^1.2.0
-        version: 1.2.0(12e67152b4d71a2eebfd84e2ae966460)
+        version: 1.2.0(742489ffa3057c9e7fd2414b899eaac6)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
+      '@glint/ember-tsc':
+        specifier: ^1.5.0
+        version: 1.5.0(typescript@6.0.2)
+      '@glint/template':
+        specifier: ^1.7.7
+        version: 1.7.7
       '@rollup/plugin-babel':
         specifier: ^7.0.0
         version: 7.0.0(@babel/core@7.28.4)(rollup@4.53.3)
@@ -81,7 +87,7 @@ importers:
         version: 4.53.3
       testing-library-ember:
         specifier: ^1.0.0
-        version: 1.0.0(f727ee3f17ca094991e78108bbf7f558)
+        version: 1.0.0(426a7b9820d462c5ca1481ea152f4b27)
       typescript:
         specifier: ^6.0.0
         version: 6.0.2
@@ -1031,6 +1037,15 @@ packages:
   '@glimmer/wire-format@0.94.8':
     resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
 
+  '@glint/ember-tsc@1.5.0':
+    resolution: {integrity: sha512-mMAG91QyzKQvklnoQFy5orNA4gYU2LPQlPHUbJnuAHJ0c5pwyUO/rjseudFXAWRA5F8cQmNLqtximnLTvHSMzw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.6.0'
+
+  '@glint/template@1.7.7':
+    resolution: {integrity: sha512-jcPdQ3A6cXo5h9RBi0tK4/o5qNn7868Y8xpkwWQNPAd8xQKuRKmG9dGJwUycXvtqISzfrnL1p3MQr3hYN/Ua6Q==}
+
   '@handlebars/parser@2.2.1':
     resolution: {integrity: sha512-D76vKOZFEGA9v6g0rZTYTQDUXNopCblW1Zeas3EEVrbdeh8gWrCEO9/goocKmcgtqAwv1Md76p58UQp7HeFTEw==}
     engines: {node: ^18 || ^20 || ^22 || >=24}
@@ -1561,6 +1576,32 @@ packages:
   '@vitest/utils@4.0.13':
     resolution: {integrity: sha512-ydozWyQ4LZuu8rLp47xFUWis5VOKMdHjXCWhs1LuJsTNKww+pTHQNK4e0assIB9K80TxFyskENL6vCu3j34EYA==}
 
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-server@2.4.28':
+    resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/test-utils@2.4.28':
+    resolution: {integrity: sha512-N7RNiHHDPtqK5B21x4W462XMQj7Z75ynN3isLP+3Rb44hbJjhxxDxzs+QqWB0sjM57EtTJga+SDd9WWy3OjMzA==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
   '@wdio/config@9.20.1':
     resolution: {integrity: sha512-npl2J+rjCDJPjVySgWpciOyhWddn6s7n5sepKXLR7x1ADQHl5zUFv1dHD3jx4OQ9l6lrGQSPaofuz+7e9mu+vg==}
     engines: {node: '>=18.20.0'}
@@ -2047,6 +2088,9 @@ packages:
 
   content-tag@4.0.0:
     resolution: {integrity: sha512-qqJiY9nueYAI396MOmfOk+w/0KL6ERKxANQcSKcR0CrNTc38yT//b73l+WHr9brZx57bFHNaW7a/6Yll0bn95w==}
+
+  content-tag@4.1.1:
+    resolution: {integrity: sha512-LyIbq4ZY+WbN0NoyHmg0w1kLPHyXZkZZrTDJZm/HW+MVurnKJy7U3m8WlpKm6lqbYbUSWP6ATNacE5dL2eH8+g==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3393,6 +3437,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -3634,6 +3681,9 @@ packages:
 
   remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
+
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4063,6 +4113,12 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
+
   typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
@@ -4275,6 +4331,48 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  volar-service-html@0.0.70:
+    resolution: {integrity: sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.70:
+    resolution: {integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-html-languageservice@5.6.2:
+    resolution: {integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -5256,11 +5354,11 @@ snapshots:
 
   '@ember/library-tsconfig@2.0.0': {}
 
-  '@ember/test-helpers@5.4.0(@babel/core@7.28.4)':
+  '@ember/test-helpers@5.4.0(8612da301a9a8aaf6d70030350e5df34)':
     dependencies:
-      '@ember/test-waiters': 4.1.1
+      '@ember/test-waiters': 4.1.1(@glint/template@1.7.7)
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.1
+      '@embroider/macros': 1.18.1(@glint/template@1.7.7)
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.28.4)
       dom-element-descriptors: 0.5.1
@@ -5269,17 +5367,17 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/test-waiters@4.1.1':
+  '@ember/test-waiters@4.1.1(@glint/template@1.7.7)':
     dependencies:
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.1
+      '@embroider/macros': 1.18.1(@glint/template@1.7.7)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@embroider/addon-dev@8.1.2(rollup@4.53.3)':
+  '@embroider/addon-dev@8.1.2(@glint/template@1.7.7)(rollup@4.53.3)':
     dependencies:
-      '@embroider/core': 4.2.8
+      '@embroider/core': 4.2.8(@glint/template@1.7.7)
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       content-tag: 3.1.3
       execa: 5.1.1
@@ -5306,12 +5404,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/core@4.2.0':
+  '@embroider/core@4.2.0(@glint/template@1.7.7)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/parser': 7.28.4
       '@babel/traverse': 7.28.4
-      '@embroider/macros': 1.18.1
+      '@embroider/macros': 1.18.1(@glint/template@1.7.7)
       '@embroider/reverse-exports': 0.1.2
       '@embroider/shared-internals': 3.0.0
       assert-never: 1.4.0
@@ -5342,12 +5440,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/core@4.2.8':
+  '@embroider/core@4.2.8(@glint/template@1.7.7)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/parser': 7.28.4
       '@babel/traverse': 7.28.4
-      '@embroider/macros': 1.19.4
+      '@embroider/macros': 1.19.4(@glint/template@1.7.7)
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 3.0.1
       assert-never: 1.4.0
@@ -5378,7 +5476,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/macros@1.18.1':
+  '@embroider/macros@1.18.1(@glint/template@1.7.7)':
     dependencies:
       '@embroider/shared-internals': 3.0.0
       assert-never: 1.4.0
@@ -5388,10 +5486,12 @@ snapshots:
       lodash: 4.17.21
       resolve: 1.22.10
       semver: 7.7.2
+    optionalDependencies:
+      '@glint/template': 1.7.7
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/macros@1.19.4':
+  '@embroider/macros@1.19.4(@glint/template@1.7.7)':
     dependencies:
       '@embroider/shared-internals': 3.0.1
       assert-never: 1.4.0
@@ -5401,6 +5501,8 @@ snapshots:
       lodash: 4.17.21
       resolve: 1.22.10
       semver: 7.7.2
+    optionalDependencies:
+      '@glint/template': 1.7.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5450,11 +5552,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/vite@1.2.0(12e67152b4d71a2eebfd84e2ae966460)':
+  '@embroider/vite@1.2.0(742489ffa3057c9e7fd2414b899eaac6)':
     dependencies:
       '@babel/core': 7.28.4
-      '@embroider/core': 4.2.0
-      '@embroider/macros': 1.18.1
+      '@embroider/core': 4.2.0(@glint/template@1.7.7)
+      '@embroider/macros': 1.18.1(@glint/template@1.7.7)
       '@embroider/reverse-exports': 0.1.2
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       assert-never: 1.4.0
@@ -5693,6 +5795,30 @@ snapshots:
   '@glimmer/wire-format@0.94.8':
     dependencies:
       '@glimmer/interfaces': 0.94.6
+
+  '@glint/ember-tsc@1.5.0(typescript@6.0.2)':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': 1.7.7
+      '@volar/kit': 2.4.28(typescript@6.0.2)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 4.1.1
+      silent-error: 1.1.1
+      typescript: 6.0.2
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@glint/template@1.7.7': {}
 
   '@handlebars/parser@2.2.1': {}
 
@@ -6198,6 +6324,55 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.13
       tinyrainbow: 3.0.3
+
+  '@volar/kit@2.4.28(typescript@6.0.2)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 6.0.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-server@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/test-utils@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vscode/l10n@0.0.18': {}
 
   '@wdio/config@9.20.1':
     dependencies:
@@ -6869,6 +7044,8 @@ snapshots:
   content-tag@3.1.3: {}
 
   content-tag@4.0.0: {}
+
+  content-tag@4.1.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -8410,6 +8587,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-browserify@1.0.1: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -8665,6 +8844,8 @@ snapshots:
       prettier: 2.8.8
     transitivePeerDependencies:
       - supports-color
+
+  request-light@0.7.0: {}
 
   require-directory@2.1.1: {}
 
@@ -9064,9 +9245,9 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  testing-library-ember@1.0.0(f727ee3f17ca094991e78108bbf7f558):
+  testing-library-ember@1.0.0(426a7b9820d462c5ca1481ea152f4b27):
     dependencies:
-      '@ember/test-helpers': 5.4.0(@babel/core@7.28.4)
+      '@ember/test-helpers': 5.4.0(8612da301a9a8aaf6d70030350e5df34)
       '@embroider/addon-shim': 1.10.0
       '@testing-library/dom': 10.4.1
     transitivePeerDependencies:
@@ -9144,6 +9325,12 @@ snapshots:
   type-fest@4.26.0: {}
 
   type-fest@4.41.0: {}
+
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.7.2
 
   typescript-memoize@1.1.1: {}
 
@@ -9278,6 +9465,51 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  volar-service-html@0.0.70(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.7.2
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-html-languageservice@5.6.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/manual.ts
+++ b/src/manual.ts
@@ -4,14 +4,12 @@ import {
   setupContext as emberSetupContext,
   teardownContext,
   setApplication,
-  type Target,
 } from "@ember/test-helpers";
 import { renderComponent } from "@ember/renderer";
 import { create, createApp } from "./create-app.ts";
 
 import type EmberApplication from "@ember/application";
-import type Component from "@glimmer/component";
-import type TOC from "@ember/component/template-only";
+import type { ComponentLike } from "@glint/template";
 
 export function setupContext() {
   let element = document.createElement("div");
@@ -85,9 +83,7 @@ export async function setupRenderingContext(app?: typeof EmberApplication) {
     click(target: Parameters<typeof click>[0]) {
       return click(target);
     },
-    async render(
-      component: (new (...args: unknown[]) => Component) | typeof TOC,
-    ) {
+    async render(component: ComponentLike<unknown>) {
       let result = renderComponent(component, {
         into: element,
         owner: ctx.owner,

--- a/tests/types/render-template-types.gts
+++ b/tests/types/render-template-types.gts
@@ -1,0 +1,40 @@
+// Type-only test. This file is exercised by `pnpm types:check` (ember-tsc).
+// It locks in the consumer contract for `setupRenderingContext().render(...)`.
+//
+// In particular, a bare `<template>...</template>` expression evaluates to a
+// `TemplateOnlyComponent` value, and must be accepted by `render`.
+
+import Component from "@glimmer/component";
+import { setupRenderingContext } from "ember-vitest";
+
+// Inline `<template>...</template>` expression.
+async function inlineTemplateExpression() {
+  using ctx = await setupRenderingContext();
+  await ctx.render(<template>hello there</template>);
+}
+
+// `<template>` assigned to a const, then passed in.
+const Greeting = <template>hello there</template>;
+async function templateConst() {
+  using ctx = await setupRenderingContext();
+  await ctx.render(Greeting);
+}
+
+// Class component with an embedded `<template>`.
+class Counter extends Component {
+  count = 0;
+
+  <template>
+    <output>{{this.count}}</output>
+  </template>
+}
+
+async function classComponent() {
+  using ctx = await setupRenderingContext();
+  await ctx.render(<template><Counter /></template>);
+  await ctx.render(Counter);
+}
+
+// Suppress "declared but never read" for the helpers; they exist solely so
+// ember-tsc can typecheck the bodies above.
+export { inlineTemplateExpression, templateConst, classComponent };

--- a/tsconfig.glint.json
+++ b/tsconfig.glint.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@ember/library-tsconfig",
+  "include": ["./src/**/*", "./tests/types/**/*"],
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["esnext", "dom"],
+
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    "declaration": false,
+    "declarationMap": false,
+
+    "types": ["ember-source/types"],
+
+    "paths": {
+      "ember-vitest": ["./src/index.ts"],
+      "ember-vitest/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
The previous union rejected `<template>...</template>` expressions. Switch to `ComponentLike<unknown>` from `@glint/template`, added as an optional peer dependency.

Adds an `ember-tsc` based `types:check` script and a types test that locks the contract for inline templates, template consts, and class components.